### PR TITLE
Support sprockets up to 3.0

### DIFF
--- a/sprockets-illusionist.gemspec
+++ b/sprockets-illusionist.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake'
-  spec.add_dependency 'sprockets', '~> 2.10.1'
+  spec.add_dependency 'sprockets', '>= 2.10.1', '< 3.0'
 end


### PR DESCRIPTION
I don’t think there was a specific reason we had it locked up to `2.10.1`.
